### PR TITLE
Add LilyPond installation to Cloudflare build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const output = `${{ steps.deploy.outputs.deployment-url }}`;
+            const output = `${{ steps.deploy.outputs.pages-deployment-alias-url }}`;
             const body = `### 🚀 Preview Deployment\n\n` +
               `Your changes have been deployed to:\n` +
               `**${output}**\n\n` +


### PR DESCRIPTION
- Add build.sh that downloads prebuilt LilyPond binary from GitLab releases
- Add wrangler.toml to configure Cloudflare Pages build command
- Update compile-lilypond.js to warn instead of fail when LilyPond unavailable

This allows the site to build in Cloudflare's cloud build environment, which doesn't support apt-get due to sandboxing restrictions.